### PR TITLE
adds support for patching containers, initcontainers and volumes via wildcard in name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # k8s-pod-mutator-webhook
 [![Webhook Image Build](https://img.shields.io/docker/cloud/automated/bohlenc/k8s-pod-mutator-webhook?label=webhook%20build)](https://hub.docker.com/r/bohlenc/k8s-pod-mutator-webhook) [![Webhook Image Version](https://img.shields.io/docker/v/bohlenc/k8s-pod-mutator-webhook?label=webhook&sort=semver)](https://hub.docker.com/r/bohlenc/k8s-pod-mutator-webhook) [![Init Image Build](https://img.shields.io/docker/cloud/automated/bohlenc/k8s-pod-mutator-init?label=init%20build)](https://hub.docker.com/r/bohlenc/k8s-pod-mutator-webhook) [![Init Image Version](https://img.shields.io/docker/v/bohlenc/k8s-pod-mutator-init?label=init&sort=semver)](https://hub.docker.com/r/bohlenc/k8s-pod-mutator-init)
 
-This is a Kubernetes Mutating Admission Webhook (see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
+This is a Kubernetes Mutating Admission Webhook (see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/). 
 It can apply arbitrary changes (a "patch") to a Pod's manifest. A patch can do anything from adding or changing metadata to containers and init-containers with volumes.
 
-The Kubernetes API server only supports communication with webhooks over HTTPS - 
-an init-container is included that automates cert generation and any necessary configuration (i.e. applying the `caBundle` to the `MutatingWebhookConfiguration`).
+The Kubernetes API server only supports communication with webhooks over HTTPS - an init-container is included that automates cert generation 
+and any necessary configuration (i.e. applying the `caBundle` to the `MutatingWebhookConfiguration`).
+
 
 ## Problem Statement
 
-It is a recurring requirement in Kubernetes deployments to transparently mutate Pod manifests - 
-either to add new functionality transparently to existing deployments and applications, or to enforce compliance and other policies and requirements. 
+It is a recurring requirement in Kubernetes deployments to transparently mutate Pod manifests - either to add new functionality transparently to existing deployments 
+and applications, or to enforce compliance and other policies and requirements.
 
 This webhook provides a flexible and scalable solution to those problems.
 
@@ -18,33 +19,41 @@ This webhook provides a flexible and scalable solution to those problems.
 ## Notable Options
 
 ### --patch
+
 Path to the YAML file containing the patch to be applied to eligible Pods (see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#pod-v1-core for help).
 
+Patches support wildcards ("*") instead of specific names for containers, init-containers and volumes. 
+If a wildcard is specified, the operation is applied to all existing containers/init-containers/volumes (see [examples](#Examples)). 
+
+A patch can contain wildcard and regular operations simultaneously.
+
+A patch can contain only one wildcard per type (container/init-container/volume) currently.
+
 ### --log-level
+
 panic | fatal | error | warn | info | debug | trace
 
 
 ## Installation
 
 ### Helm
+
 1. adjust the `values.yaml` in `deploy/helm` to your requirements
 2. install the chart via `helm install k8s-pod-mutator deploy/helm -f deploy/helm/values.yaml`
 
-
 By default, the webhook is reachable under "https://<service_name>:8443/mutate"
-
 
 ## Examples
 
 Issue: https://github.com/Azure/azure-sdk-for-net/issues/18312
 
 To apply the workaround proposed [here](https://github.com/Azure/azure-sdk-for-net/issues/18312#issuecomment-771116456)
-simply install the Helm chart with the provided example values: 
+simply install the Helm chart with the provided example values:
 
 `helm upgrade --install k8s-pod-mutator deploy/helm -f values.yaml -f examples/values.example.yaml`.
 
 This example adds an init-container
-```
+```yaml
 spec:
   initContainers:
     - name: wait-for-imds
@@ -52,6 +61,31 @@ spec:
       command: ['sh', '-c', 'wget "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/" --header "Metadata: true" -S --spider -T 6']
 ```
 to all Pods that have a Label `aadpodidbinding`.
+
+---
+
+Feature Request: https://github.com/bohlenc/k8s-pod-mutator-webhook/issues/3
+
+Consider the following patch:
+```yaml
+spec:
+  initContainers:
+  - name: ca
+    image: alpine
+    command: ["sh", "-c", "cp -r /etc/ssl/certs /volume"]
+    volumeMounts:
+    - mountPath: /volume
+      name: cacerts
+  containers:
+  - name: "*"
+    volumeMounts:
+    - mountPath: /etc/ssl
+      name: cacerts
+  volumes:
+  - name: cacerts
+    emptyDir: {}
+```
+When this patch is applied, the `volumeMount` "cacerts" is added to all containers currently present in the pod.
 
 
 ## Contributions

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module k8s-pod-mutator-webhook
 
 require (
+	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
@@ -8,6 +9,7 @@ require (
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
+	sigs.k8s.io/yaml v1.2.0
 )
 
 go 1.15

--- a/pkg/mutator/mutator_test.go
+++ b/pkg/mutator/mutator_test.go
@@ -1,290 +1,423 @@
 package mutator
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"gomodules.xyz/jsonpatch/v3"
 	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
 )
 
-// TODO: readability of expectations
 func TestMutator_MutateCanApplyChanges(t *testing.T) {
 	testCases := []struct {
-		objectRaw string
-		patch     string
-		expected  string
+		pod               string
+		patch             string
+		expectedJsonPatch string
 	}{
 		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod"
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
 			patch: `
-				{
-				  "spec": {
-					"initContainers": [
-					  {
-						"name": "wait-for-imds",
-						"image": "busybox:1.33",
-						"command": [
-						  "sh",
-						  "-c",
-						  "wget \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/\" --header \"Metadata: true\" -S --spider -T 6"
-						]
-					  }
-					]
-				  }
-				}`,
-			expected: "[{\"op\":\"add\",\"path\":\"/metadata/annotations\",\"value\":{\"k8s-pod-mutator.io/mutated\":\"true\"}},{\"op\":\"add\",\"path\":\"/spec/initContainers\",\"value\":[{\"name\":\"wait-for-imds\",\"image\":\"busybox:1.33\",\"command\":[\"sh\",\"-c\",\"wget \\\"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01\\u0026resource=https://management.azure.com/\\\" --header \\\"Metadata: true\\\" -S --spider -T 6\"],\"resources\":{}}]}]",
+spec:
+  initContainers:
+  - name: wait-for-imds
+    image: busybox:1.33
+    command: [
+      "sh",
+      "-c",
+      "wget \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/\" --header \"Metadata: true\" -S --spider -T 6"
+    ]
+`,
+			expectedJsonPatch: `
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "k8s-pod-mutator.io/mutated": "true"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "command": [
+          "sh",
+          "-c",
+          "wget \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/\" --header \"Metadata: true\" -S --spider -T 6"
+        ],
+        "image": "busybox:1.33",
+        "name": "wait-for-imds",
+        "resources": {}
+      }
+    ]
+  }
+]
+`,
 		},
 		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod"
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
 			patch: `
-				{
-				  "spec": {
-					"containers": [
-					  {
-						"name": "busybox",
-						"image": "busybox"
-					  }
-					]
-				  }
-				}`,
-			expected: "[{\"op\":\"add\",\"path\":\"/metadata/annotations\",\"value\":{\"k8s-pod-mutator.io/mutated\":\"true\"}},{\"op\":\"add\",\"path\":\"/spec/containers/1\",\"value\":{\"name\":\"alpine\",\"image\":\"alpine\",\"resources\":{}}},{\"op\":\"replace\",\"path\":\"/spec/containers/0/name\",\"value\":\"busybox\"},{\"op\":\"replace\",\"path\":\"/spec/containers/0/image\",\"value\":\"busybox\"}]",
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+`,
+			expectedJsonPatch: `
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "k8s-pod-mutator.io/mutated": "true"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "image": "alpine",
+      "name": "alpine",
+      "resources": {}
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/image",
+    "value": "busybox"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/name",
+    "value": "busybox"
+  }
+]
+`,
 		},
 		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod"
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
 			patch: `
-				{
-				  "spec": {
-					"containers": [
-					  {
-						"name": "busybox",
-						"image": "busybox",
-						"volumeMounts": [
-						  {
-							"name": "test",
-							"mountPath": "/tmp/test"
-						  }
-						]
-					  }
-					],
-					"volumes": [
-					  {
-						"name": "test",
-						"emptyDir": {}
-					  }
-					]
-				  }
-				}`,
-			expected: "[{\"op\":\"add\",\"path\":\"/metadata/annotations\",\"value\":{\"k8s-pod-mutator.io/mutated\":\"true\"}},{\"op\":\"add\",\"path\":\"/spec/volumes\",\"value\":[{\"name\":\"test\",\"emptyDir\":{}}]},{\"op\":\"add\",\"path\":\"/spec/containers/1\",\"value\":{\"name\":\"alpine\",\"image\":\"alpine\",\"resources\":{}}},{\"op\":\"replace\",\"path\":\"/spec/containers/0/name\",\"value\":\"busybox\"},{\"op\":\"replace\",\"path\":\"/spec/containers/0/image\",\"value\":\"busybox\"},{\"op\":\"add\",\"path\":\"/spec/containers/0/volumeMounts\",\"value\":[{\"name\":\"test\",\"mountPath\":\"/tmp/test\"}]}]",
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    volumeMounts:
+    - name: test
+      mountPath: /tmp/test
+  volumes:
+  - name: test
+    emptyDir: {}
+`,
+			expectedJsonPatch: `
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "k8s-pod-mutator.io/mutated": "true"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "image": "alpine",
+      "name": "alpine",
+      "resources": {}
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/image",
+    "value": "busybox"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/name",
+    "value": "busybox"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/volumeMounts",
+    "value": [
+      {
+        "mountPath": "/tmp/test",
+        "name": "test"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "emptyDir": {},
+        "name": "test"
+      }
+    ]
+  }
+]
+`,
+		},
+		{
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "container1",
+		"image": "alpine"
+	  },
+	  {
+		"name": "container2",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
+			patch: `
+spec:
+  initContainers:
+  - name: ca
+    image: alpine
+    command: ["sh", "-c", "cp -r /etc/ssl/certs /volume"]
+    volumeMounts:
+    - mountPath: /volume
+      name: cacerts
+  containers:
+  - name: "*"
+    volumeMounts:
+    - mountPath: /etc/ssl
+      name: cacerts
+  volumes:
+  - name: cacerts
+    emptyDir: {}
+`,
+			expectedJsonPatch: `
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "k8s-pod-mutator.io/mutated": "true"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/volumeMounts",
+    "value": [
+      {
+        "mountPath": "/etc/ssl",
+        "name": "cacerts"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1/volumeMounts",
+    "value": [
+      {
+        "mountPath": "/etc/ssl",
+        "name": "cacerts"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "command": [
+          "sh",
+          "-c",
+          "cp -r /etc/ssl/certs /volume"
+        ],
+        "image": "alpine",
+        "name": "ca",
+        "resources": {},
+        "volumeMounts": [
+          {
+            "mountPath": "/volume",
+            "name": "cacerts"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "emptyDir": {},
+        "name": "cacerts"
+      }
+    ]
+  }
+]
+`,
 		},
 	}
 
-	for _, testCase := range testCases {
+	for testNo, testCase := range testCases {
 		admissionRequest := v1.AdmissionRequest{
 			Object: runtime.RawExtension{
-				Raw: []byte(testCase.objectRaw),
+				Raw: []byte(testCase.pod),
 			},
 		}
 		mutator := &Mutator{
-			patchJsonBytes: []byte(testCase.patch),
+			patch: createPatch(testCase.patch),
 		}
 
 		admissionResponse := mutator.Mutate(&admissionRequest)
-		assert.Equal(t, testCase.expected, string(admissionResponse.Patch))
-	}
-}
+		println(fmt.Sprintf("TestNo: %v", testNo))
 
-func TestMutator_MutateFailsOnError(t *testing.T) {
-	testCases := []struct {
-		objectRaw string
-		patch     string
-	}{
-		{
-			objectRaw: "{ invalid pod }",
-			patch: `
-				{
-				  "spec": {
-					"containers": [
-					  {
-						"name": "busybox",
-						"image": "busybox"
-					  }
-					]
-				  }
-				}`,
-		},
-		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod"
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
-			patch: "{ invalid patch }",
-		},
-	}
-
-	for _, testCase := range testCases {
-		admissionRequest := v1.AdmissionRequest{
-			Object: runtime.RawExtension{
-				Raw: []byte(testCase.objectRaw),
-			},
-		}
-		mutator := &Mutator{
-			patchJsonBytes: []byte(testCase.patch),
-		}
-
-		admissionResponse := mutator.Mutate(&admissionRequest)
-		assert.Equal(t, int32(500), admissionResponse.Result.Code)
-		assert.Equal(t, "Failure", admissionResponse.Result.Status)
-		assert.NotNil(t, admissionResponse.Result.Message)
+		expected := unmarshalJsonPatch([]byte(testCase.expectedJsonPatch))
+		actual := unmarshalJsonPatch(admissionResponse.Patch)
+		assert.ElementsMatch(t, expected, actual)
 	}
 }
 
 func TestMutator_MutateConsidersStatusAnnotationForEligibility(t *testing.T) {
 	testCases := []struct {
-		objectRaw     string
-		patchExpected bool
+		pod                  string
+		expectHasBeenPatched bool
 	}{
 		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod",
-					"annotations": {
-						"k8s-pod-mutator.io/mutated":"true"
-					}
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
-			patchExpected: false,
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod",
+	"annotations": {
+		"k8s-pod-mutator.io/mutated": "true"
+	}
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
+			expectHasBeenPatched: false,
 		},
 		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod"
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
-			patchExpected: true,
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
+			expectHasBeenPatched: true,
 		},
 		{
-			objectRaw: `
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod",
-					"annotations": {
-						"k8s-pod-mutator.io/mutated":"false"
-					}
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`,
-			patchExpected: true,
+			pod: `
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod",
+	"annotations": {
+		"k8s-pod-mutator.io/mutated": "false"
+	}
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
+			expectHasBeenPatched: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		admissionRequest := v1.AdmissionRequest{
 			Object: runtime.RawExtension{
-				Raw: []byte(testCase.objectRaw),
+				Raw: []byte(testCase.pod),
 			},
 		}
 		mutator := &Mutator{
-			patchJsonBytes: []byte(`
-				{
-				  "metadata":{
-					"labels":{
-					  "some-key":"some-value"
-					}
-				  }
-				}`),
+			patch: createPatch(`
+metadata:
+  labels:
+    added-label: test
+`,
+			),
 		}
 
 		admissionResponse := mutator.Mutate(&admissionRequest)
 		assert.True(t, admissionResponse.Allowed)
-		if testCase.patchExpected {
+		if testCase.expectHasBeenPatched {
 			assert.NotNil(t, admissionResponse.Patch)
 			assert.NotNil(t, admissionResponse.PatchType)
 		} else {
@@ -299,38 +432,72 @@ func TestMutator_MutateSetsStatusAnnotationTrue(t *testing.T) {
 	admissionRequest := v1.AdmissionRequest{
 		Object: runtime.RawExtension{
 			Raw: []byte(`
-				{
-				  "apiVersion":"v1",
-				  "kind":"Pod",
-				  "metadata":{
-					"name":"test-pod"
-				  },
-				  "spec":{
-					"containers":[
-					  {
-						"name":"alpine",
-						"image":"alpine"
-					  }
-					]
-				  }
-				}`),
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "test-pod"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"name": "alpine",
+		"image": "alpine"
+	  }
+	]
+  }
+}`,
+			),
 		},
 	}
 
 	mutator := &Mutator{
-		patchJsonBytes: []byte(`
-			{
-			  "metadata":{
-				"labels":{
-				  "added-label":"test"
-				}
-			  }
-			}`),
+		patch: createPatch(`
+metadata:
+  labels:
+    added-label: test
+`,
+		),
 	}
 
 	admissionResponse := mutator.Mutate(&admissionRequest)
-	assert.Equal(t,
-		"[{\"op\":\"add\",\"path\":\"/metadata/labels\",\"value\":{\"added-label\":\"test\"}},{\"op\":\"add\",\"path\":\"/metadata/annotations\",\"value\":{\"k8s-pod-mutator.io/mutated\":\"true\"}}]",
-		string(admissionResponse.Patch),
-	)
+
+	expected := unmarshalJsonPatch([]byte(`
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "k8s-pod-mutator.io/mutated": "true"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": {
+      "added-label": "test"
+    }
+  }
+]
+`))
+	actual := unmarshalJsonPatch(admissionResponse.Patch)
+
+	assert.Equal(t, expected, actual)
+}
+
+func unmarshalJsonPatch(patchBytes []byte) []jsonpatch.Operation {
+	var patch []jsonpatch.Operation
+	err := json.Unmarshal(patchBytes, &patch)
+	if err != nil {
+		panic(err)
+	}
+	return patch
+}
+
+func createPatch(patchYaml string) *Patch {
+	patch, err := CreatePatch([]byte(patchYaml))
+	if err != nil {
+		panic(err)
+	}
+	return patch
 }

--- a/pkg/mutator/patch.go
+++ b/pkg/mutator/patch.go
@@ -1,0 +1,215 @@
+package mutator
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"gomodules.xyz/jsonpatch/v3"
+	"k8s-pod-mutator-webhook/internal/logger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"sigs.k8s.io/yaml"
+	"sync"
+)
+
+const statusAnnotation = "k8s-pod-mutator.io/mutated"
+
+type Patch struct {
+	mutex     sync.Mutex
+	template  *corev1.Pod
+	wildcards Wildcards
+}
+
+type Wildcards struct {
+	initContainer *corev1.Container
+	container     *corev1.Container
+	volume        *corev1.Volume
+}
+
+func CreatePatch(patchYaml []byte) (*Patch, error) {
+	logger.Logger.WithFields(logrus.Fields{
+		"patchYaml": string(patchYaml),
+	}).Infoln("creating patch")
+
+	patch := &corev1.Pod{}
+	err := yaml.Unmarshal(patchYaml, patch)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal patch from yaml: %v", err)
+	}
+
+	patch, wildcards, err := splitWildcards(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(patch.Annotations) == 0 {
+		patch.Annotations = make(map[string]string)
+	}
+	patch.Annotations[statusAnnotation] = "true"
+
+	return &Patch{
+		template:  patch,
+		wildcards: *wildcards,
+	}, nil
+}
+
+func splitWildcards(patch *corev1.Pod) (*corev1.Pod, *Wildcards, error) {
+	logger.Logger.WithFields(logrus.Fields{
+		"patch": patch,
+	}).Tracef("splitting wildcards")
+
+	wildcardInitContainer, initContainers, err := splitContainers(patch.Spec.InitContainers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	wildcardContainer, containers, err := splitContainers(patch.Spec.Containers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	wildcardVolume, volumes, err := splitVolumes(patch.Spec.Volumes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	patch.Spec.InitContainers = initContainers
+	patch.Spec.Containers = containers
+	patch.Spec.Volumes = volumes
+
+	wildcards := &Wildcards{
+		initContainer: wildcardInitContainer,
+		container:     wildcardContainer,
+		volume:        wildcardVolume,
+	}
+
+	return patch, wildcards, nil
+}
+
+func splitContainers(allContainers []corev1.Container) (*corev1.Container, []corev1.Container, error) {
+	var wildcard *corev1.Container
+	var containers []corev1.Container
+	for _, container := range allContainers {
+		if container.Name == "*" {
+			if wildcard != nil {
+				return nil, nil, fmt.Errorf("only one wildcard is supported")
+			}
+			wildcard = &container
+		} else {
+			containers = append(containers, container)
+		}
+	}
+	logger.Logger.WithFields(logrus.Fields{
+		"wildcard":   wildcard,
+		"containers": containers,
+	}).Debugln("split containers")
+	return wildcard, containers, nil
+}
+
+func splitVolumes(allVolumes []corev1.Volume) (*corev1.Volume, []corev1.Volume, error) {
+	var wildcard *corev1.Volume
+	var volumes []corev1.Volume
+	for _, volume := range allVolumes {
+		if volume.Name == "*" {
+			if wildcard != nil {
+				return nil, nil, fmt.Errorf("only one wildcard is supported")
+			}
+			wildcard = &volume
+		} else {
+			volumes = append(volumes, volume)
+		}
+	}
+	logger.Logger.WithFields(logrus.Fields{
+		"wildcard": wildcard,
+		"volumes":  volumes,
+	}).Debugln("split volumes")
+	return wildcard, volumes, nil
+}
+
+func (p *Patch) Apply(pod *corev1.Pod) ([]byte, error) {
+	p.mutex.Lock()
+
+	p.appendApplicableWildcards(pod)
+
+	patchJson, err := json.Marshal(p.template)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal patch to json: %v", err)
+	}
+	logger.Logger.Tracef("patchJson: %v", string(patchJson))
+
+	podJson, err := json.Marshal(pod)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal pod to json: %v", err)
+	}
+	logger.Logger.Tracef("podJson: %v", string(podJson))
+
+	overlayedJson, err := strategicpatch.StrategicMergePatch(podJson, patchJson, corev1.Pod{})
+	if err != nil {
+		return nil, fmt.Errorf("could not apply strategic merge patch: %v", err)
+	}
+	logger.Logger.Tracef("overlayedJson: %v", string(overlayedJson))
+
+	jsonPatch, err := jsonpatch.CreatePatch(podJson, overlayedJson)
+	if err != nil {
+		return nil, fmt.Errorf("could not create jsonpatch: %v", err)
+	}
+
+	jsonPatch = postProcess(jsonPatch)
+
+	for i, operation := range jsonPatch {
+		if operation.Path == "/metadata/creationTimestamp" && operation.Operation == "remove" ||
+			(operation.Path == "/spec/containers" && operation.Operation == "remove") {
+			jsonPatch[i] = jsonPatch[len(jsonPatch)-1]
+			jsonPatch = jsonPatch[:len(jsonPatch)-1]
+		}
+	}
+
+	logger.Logger.Tracef("jsonPatch: %v", jsonPatch)
+
+	p.mutex.Unlock()
+
+	return json.Marshal(jsonPatch)
+}
+
+func postProcess(original []jsonpatch.Operation) []jsonpatch.Operation {
+	// workaround, or else patch contains unwanted operations resulting from unmarshalling JSON to corev1.Pod
+	var processed []jsonpatch.Operation
+	for _, operation := range original {
+		if operation.Path == "/metadata/creationTimestamp" && operation.Operation == "remove" {
+			continue
+		}
+		if operation.Path == "/spec/containers" && operation.Operation == "remove" {
+			continue
+		}
+		processed = append(processed, operation)
+	}
+	return processed
+}
+
+func (p *Patch) appendApplicableWildcards(pod *corev1.Pod) {
+	if p.wildcards.initContainer != nil {
+		p.template.Spec.InitContainers = appendContainerWildcards(pod.Spec.InitContainers, p.template.Spec.InitContainers, *p.wildcards.initContainer)
+	}
+	if p.wildcards.container != nil {
+		p.template.Spec.Containers = appendContainerWildcards(pod.Spec.Containers, p.template.Spec.Containers, *p.wildcards.container)
+	}
+	if p.wildcards.volume != nil {
+		p.template.Spec.Volumes = appendVolumeWildcards(pod.Spec.Volumes, p.template.Spec.Volumes, *p.wildcards.volume)
+	}
+}
+
+func appendContainerWildcards(podContainers []corev1.Container, patchContainers []corev1.Container, wildcard corev1.Container) []corev1.Container {
+	for _, podContainer := range podContainers {
+		wildcard.Name = podContainer.Name
+		patchContainers = append(patchContainers, wildcard)
+	}
+	return patchContainers
+}
+
+func appendVolumeWildcards(podVolumes []corev1.Volume, patchVolumes []corev1.Volume, wildcard corev1.Volume) []corev1.Volume {
+	for _, podVolume := range podVolumes {
+		wildcard.Name = podVolume.Name
+		patchVolumes = append(patchVolumes, wildcard)
+	}
+	return patchVolumes
+}

--- a/pkg/webhook/k8s_configuration.go
+++ b/pkg/webhook/k8s_configuration.go
@@ -9,7 +9,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )

--- a/pkg/webhook/k8s_configuration_test.go
+++ b/pkg/webhook/k8s_configuration_test.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 	"testing"
 )
 


### PR DESCRIPTION
Current limitations:
- only simple "*" wildcards
- only one wildcard per setting
- limited set of settings supported: containers, initContainers, volumes

May add support for specifying multiple regexes and additional settings in the future/if requested.